### PR TITLE
fix: remove caching of _MainNavigation

### DIFF
--- a/src/CSUSK.Web/Views/master.cshtml
+++ b/src/CSUSK.Web/Views/master.cshtml
@@ -35,7 +35,7 @@
 </head>
 <body>
     <div style="margin-top:70px;"></div>
-    @Html.CachedPartial("SiteLayout/_MainNavigation", Model, 3600)
+    @Html.Partial("SiteLayout/_MainNavigation", Model)
 
     @RenderBody()
 


### PR DESCRIPTION
Since the navigation menu contains styling of the current page, the caching breaks this.